### PR TITLE
Bugfixes for watcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+#### 3.1.7
+
+* Fix a bug with watcher where it would watch a single directory once
+* Hide watcher warnings while it's initializing
+
 #### 3.1.6
 
 * Fix a file-specific deadlock in watcher after an error was encountered

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ucompiler",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "description": "Universal assets compiler",
   "main": "lib/main.js",
   "bin": {

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -51,7 +51,9 @@ export class Watcher {
     const watcher = Chokidar.watch([])
     const watcherCallback = (filePath, stats) => {
       const promise = this.handleChange(filePath, stats).catch(_ => {
-        this.options.errorCallback(_)
+        if (this.watcherReady) {
+          this.options.errorCallback(_)
+        }
         this.locks.delete(filePath)
       })
       if (!this.watcherReady) {

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -59,10 +59,15 @@ export class Watcher {
       }
     }
 
+    const watchedPaths = new Set()
     for (const ruleName of this.ruleNames) {
       const config = getConfigRule(this.config, ruleName)
       for (const rule of config.include) {
-        watcher.add(Path.join(this.rootDirectory, rule.directory))
+        const directoryPath = Path.join(this.rootDirectory, rule.directory)
+        if (!watchedPaths.has(directoryPath)) {
+          watcher.add(directoryPath)
+          watchedPaths.add(directoryPath)
+        }
       }
     }
 


### PR DESCRIPTION
- Do not watch a path twice
- Hide warnings during initialization
